### PR TITLE
Fix Kqueue init

### DIFF
--- a/src/main/java/com/github/steveice10/packetlib/tcp/TcpClientSession.java
+++ b/src/main/java/com/github/steveice10/packetlib/tcp/TcpClientSession.java
@@ -300,6 +300,7 @@ public class TcpClientSession extends TcpSession {
                 EVENT_LOOP_GROUP = new KQueueEventLoopGroup();
                 CHANNEL_CLASS = KQueueSocketChannel.class;
                 DATAGRAM_CHANNEL_CLASS = KQueueDatagramChannel.class;
+                break;
             case NIO:
                 EVENT_LOOP_GROUP = new NioEventLoopGroup();
                 CHANNEL_CLASS = NioSocketChannel.class;


### PR DESCRIPTION
This commit fixes the KQueue init by adding a break and stopping him to reinit all the loop groop with NIO's one